### PR TITLE
Fix nlog config package restore failure

### DIFF
--- a/YazilimDestekSistemi.UI.Win/nlog.config
+++ b/YazilimDestekSistemi.UI.Win/nlog.config
@@ -5,6 +5,22 @@
       throwConfigExceptions="true">
 
   <targets>
+    <target xsi:type="File" name="logfile" fileName="${basedir}/logs/app.log" layout="${longdate} | ${level:uppercase=true} | ${logger} | ${message} ${exception:format=tostring}" />
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="logfile" />
+  </rules>
+
+</nlog>
+
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwConfigExceptions="true">
+
+  <targets>
     <target name="logfile" xsi:type="File" fileName="${basedir}/logs/app-${shortdate}.log" layout="${longdate}|${level:uppercase=true}|${logger}|${message} ${exception:format=toString}" />
     <target name="console" xsi:type="Console" layout="${longdate}|${level:uppercase=true}|${logger}|${message} ${exception:format=toString}" />
   </targets>

--- a/YazilimDestekSistemi.UI.Win/packages.config
+++ b/YazilimDestekSistemi.UI.Win/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
   <package id="NLog" version="5.2.0" targetFramework="net472" />
-  <package id="NLog.Config" version="5.2.0" targetFramework="net472" />
   <package id="NLog.Schema" version="5.2.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Removes the unavailable `NLog.Config` NuGet package and adds a local `nlog.config` file to resolve package restore errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-6732f565-be93-4b1e-9dd3-1ff6564f20a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6732f565-be93-4b1e-9dd3-1ff6564f20a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

